### PR TITLE
Prevent user from sending string instead of int via the API

### DIFF
--- a/js/jquery.chocolat.js
+++ b/js/jquery.chocolat.js
@@ -83,7 +83,7 @@
             },
 
             goto : function(i){ // open alias
-                that.open(i);
+                this.open(i);
             },
             current : function(){
                 return that.currentImage;


### PR DESCRIPTION
I had the case where I sent a string instead of an integer to the API and the prev and next button wouldn't work anymore.
