### PR TITLE
fixed destroy method, added 'chocolat' parameter to removeData() 

### DIFF
--- a/src/js/jquery.chocolat.js
+++ b/src/js/jquery.chocolat.js
@@ -288,7 +288,7 @@
         },
 
         destroy: function() {
-            this.element.removeData()
+            this.element.removeData('chocolat')
             this.element.find(this.settings.imageSelector).off('click.chocolat')
 
             if (!this.settings.initialized) {


### PR DESCRIPTION
I have added 'chocolat' key to removeData call in destroy method. Without this key it was removing all other data eg. destroying other plugins.