### PR TITLE
Add imageSource option to native JS

### DIFF
--- a/dist/js/chocolat.js
+++ b/dist/js/chocolat.js
@@ -3371,6 +3371,7 @@
 	  currentImageIndex: undefined,
 	  allowZoom: true,
 	  closeOnBackgroundClick: true,
+	  imageSource: "href",
 	  setTitle: function setTitle() {
 	    return '';
 	  },
@@ -3420,7 +3421,7 @@
 
 	        this.images.push({
 	          title: el.getAttribute('title'),
-	          src: el.getAttribute('href'),
+                  src: el.getAttribute(settings.imageSource),
 	          srcset: el.getAttribute('data-srcset'),
 	          sizes: el.getAttribute('data-sizes')
 	        });

--- a/src/js/chocolat.js
+++ b/src/js/chocolat.js
@@ -20,7 +20,7 @@ export const defaults = {
     currentImageIndex: undefined,
     allowZoom: true,
     closeOnBackgroundClick: true,
-    imageSource: "href",
+    imageSourceAttribute: 'href',
     setTitle: function() {
         return ''
     },

--- a/src/js/chocolat.js
+++ b/src/js/chocolat.js
@@ -76,7 +76,7 @@ export class Chocolat {
             elements.forEach((el, i) => {
                 this.images.push({
                     title: el.getAttribute('title'),
-                    src: el.getAttribute(settings.imageSource),
+                    src: el.getAttribute(settings.imageSourceAttribute),
                     srcset: el.getAttribute('data-srcset'),
                     sizes: el.getAttribute('data-sizes'),
                 })

--- a/src/js/chocolat.js
+++ b/src/js/chocolat.js
@@ -20,6 +20,7 @@ export const defaults = {
     currentImageIndex: undefined,
     allowZoom: true,
     closeOnBackgroundClick: true,
+    imageSource: "href",
     setTitle: function() {
         return ''
     },
@@ -75,7 +76,7 @@ export class Chocolat {
             elements.forEach((el, i) => {
                 this.images.push({
                     title: el.getAttribute('title'),
-                    src: el.getAttribute('href'),
+                    src: el.getAttribute(settings.imageSource),
                     srcset: el.getAttribute('data-srcset'),
                     sizes: el.getAttribute('data-sizes'),
                 })


### PR DESCRIPTION
Following #41, adds `imageSource` as an option to override the `href`-attribute for source.